### PR TITLE
Changes laser spot size unit to micrometer

### DIFF
--- a/info.ipynb
+++ b/info.ipynb
@@ -231,7 +231,7 @@
       "             'ACCL:IN20:300:L0A_PDES': '(deg)',\n",
       "             'ACCL:IN20:400:L0B_ADES': '(MV)',\n",
       "             'ACCL:IN20:400:L0B_PDES': '(deg)',\n",
-      "             'CAMR:IN20:186:R_DIST': '(mm)',\n",
+      "             'CAMR:IN20:186:R_DIST': '(µm)',\n",
       "             'FBCK:BCI0:1:CHRG_S': '(pC)',\n",
       "             'OTRS:IN20:571:XRMS': 'µm',\n",
       "             'OTRS:IN20:571:YRMS': 'µm',\n",
@@ -346,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/info/pv_mapping.json
+++ b/info/pv_mapping.json
@@ -23,7 +23,7 @@
         "norm_emit_y": 1.0
     },
     "pv_unit": {
-        "CAMR:IN20:186:R_DIST": "(mm)",
+        "CAMR:IN20:186:R_DIST": "(µm)",
         "SOLN:IN20:121:BACT": "(kG*m)",
         "QUAD:IN20:121:BACT": "(kG)",
         "QUAD:IN20:122:BACT": "(kG)",


### PR DESCRIPTION
Changes the laser spot size unit to micrometer. The lcls elog entries confirm this to be the correct unit for the rms values of PV `CAMR:IN20:186` rather than millimeters as stated by the original model documentation.