### PR TITLE
Update MLFlow registration to latest LUME-Model

### DIFF
--- a/k2eg/k2eg_output.py
+++ b/k2eg/k2eg_output.py
@@ -62,10 +62,8 @@ k2eg_client = k2eg.dml('lcls', 'app-three')
 step = 0
 with mlflow.start_run(run_name=run_name) as run:
     logger.info("Started MLflow run.")
-    input_example = torch.load("../info/inputs_small.pt")
-    input_example = lume_module.model.input_transformers[0].untransform(input_example)
     #Register model to mlflow
-    lume_module.register_to_mlflow(input_example, "model", "lcls_cu_injector_model", run_name=run_name)
+    lume_module.register_to_mlflow("model", "lcls_cu_injector_model", run_name=run_name)
 
     try:
         while not stop_requested:

--- a/k2eg/k2eg_output_p4p.py
+++ b/k2eg/k2eg_output_p4p.py
@@ -49,10 +49,8 @@ k2eg_client = k2eg.dml('lcls', 'app-three')
 step = 0
 with mlflow.start_run(run_name=run_name) as run:
     logger.info("Started MLflow run.")
-    input_example = torch.load("../info/inputs_small.pt")
-    input_example = lume_module.model.input_transformers[0].untransform(input_example)
     #Register model to mlflow
-    lume_module.register_to_mlflow(input_example, "model", "lcls_cu_injector_model", run_name=run_name)
+    lume_module.register_to_mlflow("model", "lcls_cu_injector_model", run_name=run_name)
 
 
     try:

--- a/k2eg/k2eg_output_p4p.py
+++ b/k2eg/k2eg_output_p4p.py
@@ -52,7 +52,6 @@ with mlflow.start_run(run_name=run_name) as run:
     #Register model to mlflow
     lume_module.register_to_mlflow("model", "lcls_cu_injector_model", run_name=run_name)
 
-
     try:
         while True:
             input_parameter_values = {}

--- a/mlflow/lume_model-mlflow-integration-demo.ipynb
+++ b/mlflow/lume_model-mlflow-integration-demo.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-04-26T12:20:23.809750Z",
@@ -21,26 +21,7 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/sdf/home/g/gopikab/.local/lib/python3.10/site-packages/mlflow/pyfunc/model.py:175: UserWarning: \u001b[31mType hint used in the model's predict function is not supported for MLflow's schema validation. Type hints must be wrapped in list[...] because MLflow assumes the predict method to take multiple input instances. Specify your type hint as `list[typing.Dict[str, typing.Any]]` for a valid signature. Remove the type hint to disable this warning. To enable validation for the input data, specify input example or model signature when logging the model. \u001b[0m\n",
-      "  func_info = _get_func_info_if_type_hint_supported(predict_attr)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
@@ -58,16 +39,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Experiment: artifact_location='s3://mlflow-bucket/5', creation_time=1746036982208, experiment_id='5', last_update_time=1746036982208, lifecycle_stage='active', name='lcls-injector-ML', tags={}>"
+       "<Experiment: artifact_location='mlflow-artifacts:/742261476526561220', creation_time=1752699169877, experiment_id='742261476526561220', last_update_time=1752699169877, lifecycle_stage='active', name='lcls-injector-ML', tags={}>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -78,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -133,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,12 +134,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See function signature for reference (note that the input is different for TorchModel):"
+    "See function signature for reference:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -166,7 +147,6 @@
       "text/plain": [
        "\u001b[0;31mSignature:\u001b[0m\n",
        "\u001b[0mlume_module\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mregister_to_mlflow\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0minput\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mtorch\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTensor\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0martifact_path\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mregistered_model_name\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m \u001b[0;34m|\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mtags\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mdict\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtyping\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mAny\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m|\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
@@ -187,7 +167,6 @@
        "https://mlflow.org/docs/latest/getting-started/intro-quickstart/ for more info.\n",
        "\n",
        "Args:\n",
-       "    input: Input tensor to infer the model signature.\n",
        "    artifact_path: Path to store the model in MLflow.\n",
        "    registered_model_name: Name of the registered model in MLflow. Optional.\n",
        "    tags: Tags to add to the MLflow model. Optional.\n",
@@ -200,7 +179,7 @@
        "\n",
        "Returns:\n",
        "    Model info metadata, mlflow.models.model.ModelInfo.\n",
-       "\u001b[0;31mFile:\u001b[0m      /sdf/sw/epics/package/anaconda/envs/python3_rhel7_env/lib/python3.10/site-packages/lume_model/models/torch_module.py\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/SLAC/lume-model/lume_model/models/torch_module.py\n",
        "\u001b[0;31mType:\u001b[0m      method"
       ]
      },
@@ -214,9 +193,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🏃 View run lume-test at: http://127.0.0.1:8082/#/experiments/742261476526561220/runs/ce536dd7f16e48e69da0bd5ae8f20dbd\n",
+      "🧪 View experiment at: http://127.0.0.1:8082/#/experiments/742261476526561220\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -224,19 +211,10 @@
       "Successfully registered model 'lcls_injector_torch_module'.\n",
       "Created version '1' of model 'lcls_injector_torch_module'.\n"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "🏃 View run lume-test at: https://ard-mlflow.slac.stanford.edu/#/experiments/5/runs/fa8aef7f8c9444d2b902e65f13d58ab6\n",
-      "🧪 View experiment at: https://ard-mlflow.slac.stanford.edu/#/experiments/5\n"
-     ]
     }
    ],
    "source": [
     "model_info = lume_module.register_to_mlflow(\n",
-    "            inputs_small,\n",
     "            artifact_path=\"lcls_injector_torch_module\",\n",
     "            registered_model_name=\"lcls_injector_torch_module\", # not necessary but required for adding tags/aliases\n",
     "            tags={\"type\":\"surrogate_injector\"}, # example tag, if desired\n",
@@ -260,18 +238,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "903a29e74136466ab74d654cd92426dc",
+       "model_id": "dbc60e7a295c47618ca06d8a09957540",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Downloading artifacts:   0%|          | 0/10 [00:00<?, ?it/s]"
+       "Downloading artifacts:   0%|          | 0/6 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -292,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,15 +315,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "🏃 View run lume-test at: https://ard-mlflow.slac.stanford.edu/#/experiments/5/runs/fa8aef7f8c9444d2b902e65f13d58ab6\n",
-      "🧪 View experiment at: https://ard-mlflow.slac.stanford.edu/#/experiments/5\n"
+      "🏃 View run lume-test at: http://127.0.0.1:8082/#/experiments/742261476526561220/runs/ce536dd7f16e48e69da0bd5ae8f20dbd\n",
+      "🧪 View experiment at: http://127.0.0.1:8082/#/experiments/742261476526561220\n"
      ]
     }
    ],
@@ -368,9 +346,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (lume-model)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python3_rhel7_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -382,7 +360,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The latest release of lume-model removes the need to specify an input example to register a model. This PR updates this code to reflect that. It will throw an error if it tries to run with the latest lume-model version.

- [ ] adjust pinned lume-model to latest version