### PR TITLE
Adding LUMETorchmodel example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+## LUMETorchModel Usage
+
+
+Adding example script demonstrating LUMETorchModel usage with the LCLS Cu Inj surrogate model.
+Shows
+1. how to load a TorchModel from YAML
+2. wrap it in LUMETorchModel
+3. use the set()/get() interface to interact with the model.
+
+To execute this example with LUMETorch, please ```pip install``` lume-torch from the [main branch](https://github.com/lume-science/lume-torch).

--- a/examples/lumetorchmodel_usage_example.py
+++ b/examples/lumetorchmodel_usage_example.py
@@ -31,9 +31,9 @@ def main():
     print(f"\nInputs: {inputs}")
     
     # Show all supported variables
-    print("\nSupported variables:")
-    print(f"  Input variables: {ltmodel.torch_model.input_names}")
-    print(f"  Output variables: {ltmodel.torch_model.output_names}")
+    print(f"\nSupported variables: {ltmodel.supported_variables}")
+    print(f"\nInput variables: {ltmodel.torch_model.input_names}")
+    print(f"\nOutput variables: {ltmodel.torch_model.output_names}")
     
     # Test reset functionality
     ltmodel.reset()

--- a/examples/lumetorchmodel_usage_example.py
+++ b/examples/lumetorchmodel_usage_example.py
@@ -1,5 +1,5 @@
 """
-Example usage of LUMETorchModel with LCLS FEL surrogate model.
+Example usage of LUMETorchModel with LCLS Cu Inj surrogate model.
 
 This script demonstrates how to:
 1. Load a TorchModel from a yaml configuration
@@ -13,7 +13,7 @@ from lume_torch.models import TorchModel
 
 def main():
     # Load the torch model from yaml configuration
-    model = TorchModel("model_config.yaml")
+    model = TorchModel("my_lume_torch_model.yaml")
     
     # Wrap it in LUMETorchModel
     ltmodel = LUMETorchModel(model)

--- a/examples/lumetorchmodel_usage_example.py
+++ b/examples/lumetorchmodel_usage_example.py
@@ -13,7 +13,7 @@ from lume_torch.models import TorchModel
 
 def main():
     # Load the torch model from yaml configuration
-    model = TorchModel("my_lume_torch_model.yaml")
+    model = TorchModel("model_config.yaml")
     
     # Wrap it in LUMETorchModel
     ltmodel = LUMETorchModel(model)

--- a/examples/lumetorchmodel_usage_example.py
+++ b/examples/lumetorchmodel_usage_example.py
@@ -1,0 +1,45 @@
+"""
+Example usage of LUMETorchModel with LCLS FEL surrogate model.
+
+This script demonstrates how to:
+1. Load a TorchModel from a yaml configuration
+2. Wrap it in LUMETorchModel for the LUME interface
+3. Set inputs and get outputs using the LUME set/get pattern
+"""
+
+from lume_torch.base import LUMETorch, LUMETorchModel
+from lume_torch.models import TorchModel
+
+
+def main():
+    # Load the torch model from yaml configuration
+    model = TorchModel("model_config.yaml")
+    
+    # Wrap it in LUMETorchModel
+    ltmodel = LUMETorchModel(model)
+    
+    # Set input values
+    print("\nSetting input: QUAD:IN20:121:BACT= -0.02")
+    ltmodel.set({"QUAD:IN20:121:BACT": -0.02})
+    
+    # Get outputs
+    outputs = ltmodel.get(ltmodel.torch_model.output_names)
+    print(f"\nOutputs: {outputs}")
+    
+    # Get inputs (to verify what was set)
+    inputs = ltmodel.get(ltmodel.torch_model.input_names)
+    print(f"\nInputs: {inputs}")
+    
+    # Show all supported variables
+    print("\nSupported variables:")
+    print(f"  Input variables: {ltmodel.torch_model.input_names}")
+    print(f"  Output variables: {ltmodel.torch_model.output_names}")
+    
+    # Test reset functionality
+    ltmodel.reset()
+    inputs_after_reset = ltmodel.get(ltmodel.torch_model.input_names)
+    print(f"\nInputs after reset: {inputs_after_reset}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adding example script demonstrating LUMETorchModel usage with the LCLS Cu Inj surrogate model. 
Shows 
1. how to load a TorchModel from YAML
2. wrap it in LUMETorchModel
3. use the set()/get() interface to interact with the model.